### PR TITLE
Widen .sheet-powerlabel .sheet-label

### DIFF
--- a/13th Age Official/13th_Age_Official.css
+++ b/13th Age Official/13th_Age_Official.css
@@ -689,7 +689,7 @@ input[type="radio"].sheet-normal:checked ~ input[type="radio"] + span::before {
 .sheet-powerlabel .sheet-label {
     color: white;
     font-size: 14px;
-    width: 100px;
+    width: 160px;
     cursor: pointer;
     margin-bottom: 5px;
 }


### PR DESCRIPTION
There's space on the sheet for 160 pixels, but only 100 are allocated.  This cuts off lots of names.  Basic attacks show that there's more room, so, let's use that room.
