### PR TITLE
Widen .sheet-powerlabel .sheet-label

### DIFF
--- a/13th Age Official/13th_Age_Official.css
+++ b/13th Age Official/13th_Age_Official.css
@@ -689,7 +689,7 @@ input[type="radio"].sheet-normal:checked ~ input[type="radio"] + span::before {
 .sheet-powerlabel .sheet-label {
     color: white;
     font-size: 14px;
-    width: 100px;
+    width: 160px;
     cursor: pointer;
     margin-bottom: 5px;
 }


### PR DESCRIPTION
The sheet power labels are set to 100px, but there's space in the form for about 160px according to the other CSS.

Since 100px cuts off lots of power/spell names, let's use that extra space.
